### PR TITLE
Bash script for Azure role assigments and diagnostic settings

### DIFF
--- a/scripts/diagnostic-settings-activity-log-at-subscriptions.sh
+++ b/scripts/diagnostic-settings-activity-log-at-subscriptions.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#Script to create or remove DataGuard's Azure Diagnostic Settings from selected Subscriptions.
+
+SAVEIFS=$IFS
+IFS=";"
+LOGS='[{"category": "Administrative","enabled": true},{"category": "Security","enabled": true},{"category": "ServiceHealth","enabled": true},{"category": "Alert","enabled": true},{"category": "Recommendation","enabled": true},{"category": "Policy","enabled": true},{"category": "Autoscale","enabled": true},{"category": "ResourceHealth","enabled": true}]'
+ACTION=""
+DIAGNOSTIC_NAME=""
+STORAGE_ACCOUNT_ID=""
+
+while getopts "n:s:t:" flag; do
+    case "${flag}" in
+        s) SUBS=$(cat ${OPTARG} | sed 's/,/;/g');;
+        t) STORAGE_ACCOUNT_ID=${OPTARG};;
+        n) DIAGNOSTIC_NAME=${OPTARG};;
+        *) echo -e 'Unknown option \n -n | Diagnostic Setting name \n -s | Subscriptions list file path \n -t | Target Storage Account resource ID'; exit 1;;
+    esac
+done
+
+shift $(( OPTIND - 1 ))
+
+case "$@" in
+    create) ACTION="create";;
+    delete) ACTION="delete";;
+    *) echo "Incorrect or missing argument. Must be 'create' or 'delete'." ; exit 1;;
+esac
+
+if [[ "${ACTION}" == "create" ]]; then
+    for s in $SUBS; do
+        echo "Creating diagnostic setting from Azure Subscription $s"
+        az monitor diagnostic-settings create --name ${DIAGNOSTIC_NAME} --resource /subscriptions/$(echo "$s" | tr -d '"') --storage-account $STORAGE_ACCOUNT_ID --logs $LOGS --resource-group abc 2>&1 | tee -a diagnostic_settings_script-log.txt
+        echo "Done"
+    done
+elif [[ "${ACTION}" == "delete" ]]; then
+    for s in $SUBS; do
+        echo "Deleting diagnostic setting from Azure Subscription $s"
+        az monitor diagnostic-settings delete --name ${DIAGNOSTIC_NAME} --resource /subscriptions/$(echo "$s" | tr -d '"') 2>&1 | tee -a diagnostic_settings_script-log.txt
+        echo "Done"
+    done
+fi

--- a/scripts/level-one-permissions-at-subscriptions.sh
+++ b/scripts/level-one-permissions-at-subscriptions.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#Script to create or remove DataGuard's DataGuard Role Assigments from selected Subscriptions.
+
+SAVEIFS=$IFS
+IFS=";"
+ROLES='{"name": "Storage Blob Data Reader", "id": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1"};{"name": "Reader", "id": "acdd72a7-3385-48ef-bd42-f606fba81ae7"}'
+APP_ID="" #Object ID of the Enterprise Application
+SUBS="" #List of Subscriptions
+
+while getopts "s:i:" flag; do
+    case "${flag}" in
+        s) SUBS=$(cat ${OPTARG} | sed 's/,/;/g');;
+        i) APP_ID=${OPTARG};;
+        *) echo -e 'Unknown option \n -i Enterprise Application object ID \n -s | Subscriptions list file path'; exit 1;;
+    esac
+done
+
+shift $(( OPTIND - 1 ))
+
+case "$@" in
+    assign) ACTION="assign";;
+    remove) ACTION="remove";;
+    *) echo "Incorrect or missing argument. Must be 'assign' or 'remove'."; exit 1;;
+esac
+
+if [[ "${ACTION}" == "assign" ]]; then
+    for s in $SUBS; do
+        for r in $ROLES; do
+        echo "Assigning $(echo "$r" | jq '. | .name') role for Azure Subscription $s"
+        az role assignment create --assignee-object-id $APP_ID --assignee-principal-type ServicePrincipal --role $(echo "$r"  | jq '. | .id' | sed 's/"//g') --scope /subscriptions/$(echo "$s" | tr -d '"') 2>&1 | tee -a level_one_permissions_script-log.txt
+        echo "Done"
+        done
+    done
+elif [[ "${ACTION}" == "remove" ]]; then
+    for s in $SUBS; do
+        for r in $ROLES; do
+        echo "Removing $(echo "$r" | jq '. | .name') role for Azure Subscription $s"
+        az role assignment delete --assignee $APP_ID --role $(echo "$r"  | jq '. | .name' | sed 's/"//g') --scope /subscriptions/$(echo "$s" | tr -d '"') 2>&1 | tee -a level_one_permissions_script-log.txt
+        echo "Done"
+        done
+    done
+fi

--- a/scripts/list-subscriptions.sh
+++ b/scripts/list-subscriptions.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+for s in $(az account list | jq '.[] | .id'); do
+    SUBS+=$s
+done
+echo $SUBS | sed 's/""/","/g' > subscriptions-list.txt


### PR DESCRIPTION
Added three scripts:
- diagnostic-settings-activity-log-at-subscriptions.sh creates or deletes diagnotic settings for activity logs per subscription
- level-one-permissions-at-subscriptions.sh assigns or removes role assigments for Reader and Storage Blob Data Reader roles per subscription
- list-subscriptions.sh lists all subscriptions IDs in format for ARM templates and previous scripts 