### PR TITLE
Fix principal ID lookup in assign-permissions script

### DIFF
--- a/scripts/assign-permissions-at-subscriptions.ps1
+++ b/scripts/assign-permissions-at-subscriptions.ps1
@@ -30,7 +30,11 @@ if (-not $tenantId -and -not $subscriptionsList ) {
 
 if (-not $principalName) {
     $principalName = Read-Host "Enter the DataGuard service principal name"
-    $principalId = $(Get-AzADServicePrincipal -DisplayName dg-test-arm-deploy).Id
+}
+$principalId = $(Get-AzADServicePrincipal -DisplayName $principalName).Id
+if (-not $principalId) {
+    Write-Host "Service principal '$principalName' not found." -ForegroundColor Red
+    exit 1
 }
 
 if (-not $action) {


### PR DESCRIPTION
**Summary:** Repairs scripts/assign-permissions-at-subscriptions.ps1 so the service principal lookup actually uses the supplied -principalName and works on both the prompt path and the CLI-args path. 

**Why this is needed**: The script is referenced from our customer-facing docs (azure-read-only-permissions, azure-dataguard-deployment-one-stop, sym-hostede2e-url-method) as the recommended way to grant DataGuard service principals Reader and Storage Blob Data Reader on a customer's subscriptions. As-shipped, the script fails for every caller because $principalId is either resolved against a hardcoded test display name or never set at all.                     

**How it works**: Customer (or Symmetry operator) authenticates Connect-AzAccount to the customer tenant, then runs the script with -principalName <SP-DisplayName> -subscriptionsList <comma-separated-IDs> -action assign. The script resolves the SP's Object ID via Get-AzADServicePrincipal -DisplayName, then iterates each subscription and calls New-AzRoleAssignment for both roles. The remove action mirrors the same flow with Remove-AzRoleAssignment for cleanup.

**What the change does**:
- Replaces the hardcoded display name dg-test-arm-deploy with the $principalName parameter.
- Moves $principalId = $(Get-AzADServicePrincipal -DisplayName $principalName).Id out of the if (-not $principalName) block so it executes whether $principalName was supplied via CLI or via prompt.                                     
- Adds an early-exit error path when the service principal isn't found, so callers see a clear message instead of an opaque null-ObjectId failure inside New-AzRoleAssignment.

**Net effect**: Before this change, the script always failed (either from looking up a nonexistent test SP, or from never setting $principalId in the CLI-args path). After this change, the script resolves the supplied SP correctly, exits cleanly when the SP doesn't exist, and successfully assigns/removes both roles. Validated end-to-end against using a throwaway service principal.  